### PR TITLE
feat: strengthen marker normalization and validation

### DIFF
--- a/tools/complete_markers.py
+++ b/tools/complete_markers.py
@@ -18,6 +18,7 @@ and the script continues – so one broken file no longer stops the whole batch.
 from __future__ import annotations
 
 import datetime as _dt
+import re
 import sys
 from pathlib import Path
 from typing import Any, Dict, List
@@ -54,8 +55,9 @@ def _ensure_examples(data: Dict[str, Any]) -> Dict[str, Any]:
     # remove duplicates while preserving order
     seen = set()
     examples = [e for e in examples if not (e in seen or seen.add(e))]
+    marker_id = data.get("id", "MARKER")
     while len(examples) < MIN_EXAMPLES:
-        examples.append(f"{data.get('id', 'MARKER')} example {len(examples)+1}")
+        examples.append(f"TODO: Add example for {marker_id}")
     data["examples"] = examples
     return data
 
@@ -69,10 +71,19 @@ def _ensure_tags(data: Dict[str, Any]) -> Dict[str, Any]:
     return data
 
 
+def _slugify(text: str) -> str:
+    """Return a lowercase slug consisting of alphanumerics and underscores."""
+    text = re.sub(r"[^0-9A-Za-z]+", "_", text)
+    return text.strip("_").lower()
+
+
 def _ensure_meta(data: Dict[str, Any], marker_path: Path) -> Dict[str, Any]:
     # id
-    if not isinstance(data.get("id"), str) or not data["id"]:
-        data["id"] = marker_path.stem
+    raw_id = data.get("id") or marker_path.stem
+    slug = _slugify(str(raw_id))
+    if not slug.startswith("ld32_"):
+        slug = f"ld32_{slug}"
+    data["id"] = slug.upper()
     # author
     if not isinstance(data.get("author"), str):
         data["author"] = "unknown"
@@ -109,10 +120,10 @@ def normalize_marker(marker_path: Path) -> tuple[str, str]:
     if not isinstance(data, dict):
         return marker_path.name, "YAML_ERROR: not a mapping"
 
+    data = _ensure_meta(data, marker_path)
     data = _ensure_frame(data)
     data = _ensure_examples(data)
     data = _ensure_tags(data)
-    data = _ensure_meta(data, marker_path)
 
     with marker_path.open("w", encoding="utf-8") as fh:
         yaml.safe_dump(data, fh, allow_unicode=True, sort_keys=False)
@@ -142,7 +153,7 @@ def main() -> None:
     print(f"Processed: {ok + bad}")
     print(f"Normalised: {ok}")
     print(f"Skipped (YAML errors): {bad}")
-    print(f"Detailed log: {SUMMARY_LOG.relative_to(Path.cwd())}")
+    print(f"Detailed log: {SUMMARY_LOG}")
 
 
 if __name__ == "__main__":

--- a/tools/qualify_marker_set.py
+++ b/tools/qualify_marker_set.py
@@ -12,6 +12,7 @@ Qualification criteria:
 """
 
 import os
+import json
 import yaml
 import shutil
 import logging
@@ -25,15 +26,22 @@ logger = logging.getLogger(__name__)
 
 class MarkerQualifier:
     """Validates and qualifies markers according to Lean Deep 3.1 model"""
-    
-    def __init__(self, marker_dir: str = "marker", final_dir: str = "final_marker_set"):
-        """Initialize the qualifier with source and destination directories"""
+
+    def __init__(
+        self,
+        marker_dir: str = "marker",
+        final_dir: str = "final_marker_set",
+        quarantine_dir: str = "quarantine",
+    ):
+        """Initialize the qualifier with directory paths"""
         self.marker_dir = Path(marker_dir)
         self.final_dir = Path(final_dir)
-        
+        self.quarantine_dir = Path(quarantine_dir)
+
         # Ensure directories exist
         self.marker_dir.mkdir(exist_ok=True)
         self.final_dir.mkdir(exist_ok=True)
+        self.quarantine_dir.mkdir(exist_ok=True)
     
     def validate_marker(self, marker_data: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -75,6 +83,8 @@ class MarkerQualifier:
         if 'id' in marker_data:
             if not marker_data['id'] or not isinstance(marker_data['id'], str):
                 errors.append("ID must be a non-empty string")
+            elif not marker_data['id'].startswith('LD32_'):
+                errors.append("ID must start with 'LD32_' prefix")
         
         return {
             'valid': len(errors) == 0,
@@ -107,17 +117,36 @@ class MarkerQualifier:
         validation_result = self.validate_marker(marker_data)
         
         if validation_result['valid']:
-            # Copy to final_marker_set
+            # Move to final_marker_set
             dest_path = self.final_dir / file_path.name
             try:
-                shutil.copy2(file_path, dest_path)
-                logger.info(f"✓ Qualified marker copied to: {dest_path}")
+                shutil.move(str(file_path), dest_path)
+                logger.info(f"✓ Qualified marker moved to: {dest_path}")
                 return True
             except Exception as e:
-                logger.error(f"Failed to copy marker to final set: {e}")
+                logger.error(f"Failed to move marker to final set: {e}")
                 return False
         else:
-            logger.warning(f"✗ Marker {file_path} failed qualification:")
+            # Move to quarantine and write error report
+            logger.warning(f"✗ Marker {file_path} failed qualification")
+            quarantine_path = self.quarantine_dir / file_path.name
+            try:
+                shutil.move(str(file_path), quarantine_path)
+            except Exception as e:
+                logger.error(f"Failed to move marker to quarantine: {e}")
+                return False
+
+            error_report = {
+                'file': file_path.name,
+                'errors': validation_result['errors'],
+            }
+            report_path = quarantine_path.with_suffix('.errors.json')
+            try:
+                with open(report_path, 'w', encoding='utf-8') as f:
+                    json.dump(error_report, f, indent=2, ensure_ascii=False)
+            except Exception as e:
+                logger.error(f"Failed to write error report: {e}")
+
             for error in validation_result['errors']:
                 logger.warning(f"  - {error}")
             return False


### PR DESCRIPTION
## Summary
- Prefix marker IDs with `LD32_` slug and pad missing examples with TODO placeholders
- Qualify markers by moving valid ones to `final_marker_set` and quarantining failures with JSON error reports

## Testing
- `python tools/complete_markers.py`
- `python tools/qualify_marker_set.py`
- `python tools/test_repair_engine.py`


------
https://chatgpt.com/codex/tasks/task_b_688e8c2b2c9083229934a4ec92770d89